### PR TITLE
Add error checking for expired/invalid tokens

### DIFF
--- a/archive_chat.py
+++ b/archive_chat.py
@@ -56,6 +56,10 @@ def list_dms(args):
 
         current_chats = json.loads(r.content)
 
+        if current_chats['meta']['code'] == 401:
+            print('Got HTTP 401 when fetching DMs, has the token expired?')
+            sys.exit(1)
+
         for chat in current_chats['response']:
             chats.append((
                         chat['other_user']['name'],

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -86,6 +86,11 @@ def fetch_group_messages(args):
     group_info = {}
 
     content = json.loads(r.content)
+
+    if content['meta']['code'] == 401:
+        print('Got HTTP 401 when fetching group messages, has the token expired?')
+        sys.exit(1)
+
     response = content['response']
 
     group_info['name'] = response['name']

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -26,6 +26,10 @@ def list_groups(args):
 
         current_chats = json.loads(r.content)
 
+        if current_chats['meta']['code'] == 401:
+            print('Got HTTP 401 when fetching groups, has the token expired?')
+            sys.exit(1)
+
         for chat in current_chats['response']:
             chats.append((chat['name'], chat['id'], chat['messages']['count']))
 

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -262,9 +262,9 @@ def main():
     args = parser.parse_args()
 
     if not args.group_chat_id and not args.direct_chat_id:
+        chats = list_groups(args)
         print("Group chats")
         print("===========")
-        chats = list_groups(args)
         table_headers = ["Chat Name", "ID", "Number of messages"]
         print(tabulate(chats, headers=table_headers))
 

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -85,7 +85,8 @@ def fetch_group_messages(args):
     messages = []
     group_info = {}
 
-    response = json.loads(r.content)['response']
+    content = json.loads(r.content)
+    response = content['response']
 
     group_info['name'] = response['name']
     group_info['description'] = response['description']

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -185,6 +185,10 @@ def fetch_direct_messages(args):
 
     curr_messages = json.loads(r.content)
 
+    if curr_messages['meta']['code'] == 401:
+        print('Got HTTP 401 when fetching direct messages, has the token expired?')
+        sys.exit(1)
+
     # TODO Check for validity of request
     num_total_messages = curr_messages['response']['count']
     num_fetched_messages = 0


### PR DESCRIPTION
The API returns 401 if the token is invalid or expired, so I added some error checks to point to the problem rather than crashing.