### PR TITLE
Implement archiving of topics / subgroups

### DIFF
--- a/archive_chat.py
+++ b/archive_chat.py
@@ -380,6 +380,9 @@ def main():
     parser.add_argument('--list-subgroups', '-l', dest='list_subgroups',
                         action='store_true',
                         help="List subgroups/topics for given group")
+    parser.add_argument('--subgroup-id', '-s', dest='subgroup_id',
+                        help="Subgroup / topic ID to archive.")
+
     args = parser.parse_args()
 
     if not args.group_chat_id and not args.direct_chat_id:
@@ -405,8 +408,12 @@ def main():
         print(tabulate(subchats, headers=table_headers))
     else:
         if args.group_chat_id:
-            messages, people, group_info, all_attachments = \
-                fetch_group_messages(args)
+            if args.subgroup_id:
+                messages, people, group_info, all_attachments = \
+                    fetch_subgroup_messages(args)
+            else:
+                messages, people, group_info, all_attachments = \
+                    fetch_group_messages(args)
         else:
             messages, people, group_info, all_attachments = \
                 fetch_direct_messages(args)

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -377,6 +377,9 @@ def main():
                         help="Use global avatars instead of " +
                              "chat specific user avatars")
 
+    parser.add_argument('--list-subgroups', '-l', dest='list_subgroups',
+                        action='store_true',
+                        help="List subgroups/topics for given group")
     args = parser.parse_args()
 
     if not args.group_chat_id and not args.direct_chat_id:
@@ -392,6 +395,14 @@ def main():
         chats = list_dms(args)
         table_headers = ["Chat Name", "ID", "Number of messages"]
         print(tabulate(chats, headers=table_headers))
+    elif args.list_subgroups:
+        if not args.group_chat_id:
+            print('Error: missing group chat ID to list subgroups.')
+            sys.exit(1)
+
+        subchats=list_subgroups(args)
+        table_headers = ["Chat Name", "ID", "Number of messages"]
+        print(tabulate(subchats, headers=table_headers))
     else:
         if args.group_chat_id:
             messages, people, group_info, all_attachments = \

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -54,7 +54,7 @@ def list_subgroups(args):
         current_chats = json.loads(r.content)
 
         for chat in current_chats['response']:
-            chats.append((chat['name'], chat['id'], chat['messages']['count']))
+            chats.append((chat['topic'], chat['id'], chat['messages']['count']))
 
         page_num += 1
         if len(current_chats['response']) == 0:

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -57,7 +57,7 @@ def list_subgroups(args):
             chats.append((chat['topic'], chat['id'], chat['messages']['count']))
 
         page_num += 1
-        if len(current_chats['response']) == 0:
+        if len(current_chats['response']) < 10:
             listing_complete = True
 
     return chats

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -199,7 +199,7 @@ def fetch_subgroup_messages(args):
 
     group_info['name'] = response['topic']
     group_info['description'] = response['description']
-    group_info['image_url'] = response['image_url']
+    group_info['image_url'] = response['avatar_url']
     group_info['created_at'] = response['created_at']
 
     for member in response['members']:

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -202,6 +202,10 @@ def fetch_subgroup_messages(args):
     group_info['image_url'] = response['avatar_url']
     group_info['created_at'] = response['created_at']
 
+    url = 'https://api.groupme.com/v3/groups/%s' % (args.group_chat_id)
+    r = requests.get(url, params=params)
+
+    response = json.loads(r.content)['response']
     for member in response['members']:
         people[member['user_id']] = {'name': member['nickname']}
         if args.save_global_avatars:

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -184,6 +184,97 @@ def fetch_group_messages(args):
     return messages, people, group_info, all_attachments
 
 
+def fetch_subgroup_messages(args):
+    params = {
+        'token': args.token
+    }
+    url = 'https://api.groupme.com/v3/groups/%s/subgroups/%s' % (args.group_chat_id, args.subgroup_id)
+    r = requests.get(url, params=params)
+
+    people = {}
+    messages = []
+    group_info = {}
+
+    response = json.loads(r.content)['response']
+
+    group_info['name'] = response['name']
+    group_info['description'] = response['description']
+    group_info['image_url'] = response['image_url']
+    group_info['created_at'] = response['created_at']
+
+    for member in response['members']:
+        people[member['user_id']] = {'name': member['nickname']}
+        if args.save_global_avatars:
+            people[member['user_id']]['avatar_url'] = member['image_url']
+        else:
+            people[member['user_id']]['avatar_url'] = None
+
+    url = 'https://api.groupme.com/v3/groups/%s/messages' % (
+           args.subgroup_id)
+    r = requests.get(url, params=params)
+
+    curr_messages = json.loads(r.content)
+
+    # TODO Check for validity of request
+    num_total_messages = curr_messages['response']['count']
+    num_fetched_messages = 0
+    curr_messages = curr_messages['response']['messages']
+    all_attachments = []
+
+    print("Fetching %d messages..." % (num_total_messages))
+    pbar = tqdm(total=num_total_messages)
+    while num_fetched_messages < num_total_messages:
+        num_fetched_messages += len(curr_messages)
+        pbar.update(len(curr_messages))
+        for message in curr_messages:
+            if message['sender_id'] not in people:
+                people[message['sender_id']] = {
+                    'name': message['name'],
+                    'avatar_url': message['avatar_url']
+                }
+            if not args.save_global_avatars and \
+               people[message['sender_id']]['avatar_url'] is None:
+                people[message['sender_id']]['avatar_url'] = \
+                    message['avatar_url']
+
+            for att in message['attachments']:
+                if att['type'] == 'image' or \
+                   att['type'] == 'video' or \
+                   att['type'] == 'linked_image':
+                    all_attachments.append(att['url'])
+            # print("[%s] %s : %s" % (
+            #    message['created_at'], message['name'], message['text']))
+            messages.append({
+                'author': message['sender_id'],
+                'created_at': message['created_at'],
+                'text': message['text'],
+                'favorited_by': message['favorited_by'],
+                'attachments': message['attachments']
+            })
+        last_message_id = curr_messages[-1]['id']
+
+        params = {
+            'token': args.token,
+            'before_id': last_message_id,
+            'limit': args.num_messages_per_request
+        }
+        url = 'https://api.groupme.com/v3/groups/%s/messages' % (
+               args.group_chat_id)
+        r = requests.get(url, params=params)
+
+        if r.status_code == 304:
+            break
+        curr_messages = json.loads(r.content)
+
+        # TODO Check for validity of request
+        curr_messages = curr_messages['response']['messages']
+
+    pbar.close()
+    messages = list(reversed(messages))
+
+    return messages, people, group_info, all_attachments
+
+
 def fetch_direct_messages(args):
     params = {
         'token': args.token,

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -36,6 +36,33 @@ def list_groups(args):
     return chats
 
 
+def list_subgroups(args):
+    headers = {'Content-Type': 'application/json'}
+    page_num = 1
+    listing_complete = False
+
+    chats = []
+    while not listing_complete:
+        params = {
+            'token': args.token,
+            'omit':  'memberships',
+            'page':  page_num
+        }
+        url = 'https://api.groupme.com/v3/groups/%s/subgroups' % (args.group_chat_id)
+        r = requests.get(url, headers=headers, params=params)
+
+        current_chats = json.loads(r.content)
+
+        for chat in current_chats['response']:
+            chats.append((chat['name'], chat['id'], chat['messages']['count']))
+
+        page_num += 1
+        if len(current_chats['response']) == 0:
+            listing_complete = True
+
+    return chats
+
+
 def list_dms(args):
     headers = {'Content-Type': 'application/json'}
     page_num = 1

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -197,7 +197,7 @@ def fetch_subgroup_messages(args):
 
     response = json.loads(r.content)['response']
 
-    group_info['name'] = response['name']
+    group_info['name'] = response['topic']
     group_info['description'] = response['description']
     group_info['image_url'] = response['image_url']
     group_info['created_at'] = response['created_at']

--- a/archive_chat.py
+++ b/archive_chat.py
@@ -53,6 +53,10 @@ def list_subgroups(args):
 
         current_chats = json.loads(r.content)
 
+        if current_chats['meta']['code'] == 401:
+            print('Got HTTP 401 when fetching subgroups, has the token expired?')
+            sys.exit(1)
+
         for chat in current_chats['response']:
             chats.append((chat['topic'], chat['id'], chat['messages']['count']))
 
@@ -195,7 +199,13 @@ def fetch_subgroup_messages(args):
     messages = []
     group_info = {}
 
-    response = json.loads(r.content)['response']
+    content = json.loads(r.content)
+
+    if content['meta']['code'] == 401:
+        print('Got HTTP 401 when fetching group messages, has the token expired?')
+        sys.exit(1)
+
+    response = content['response']
 
     group_info['name'] = response['topic']
     group_info['description'] = response['description']


### PR DESCRIPTION
Fixes #4.

This duplicates some of the existing code due to overlapping functionality, but I opted to keep things simple rather than optimizing early.

Verified that the output for subgroups appears to be correct, groups and DMs are still working, and the `render_chat.py` script works for subgroups too.

Included the error checks from #5 for only the new methods here, so both that PR and this one should be able to be merged independently.